### PR TITLE
remove need to link library by making all functions internal

### DIFF
--- a/src/Quabi.sol
+++ b/src/Quabi.sol
@@ -43,14 +43,14 @@ library Quabi {
         return selectors;
     }
 
-    function getFunctions(string memory contractName) public returns (bytes4[] memory) {
+    function getFunctions(string memory contractName) internal returns (bytes4[] memory) {
         string memory query = "'[.ast.nodes[-1].nodes[] | if .nodeType == \"FunctionDefinition\" and .kind == \"function\" then .functionSelector else empty end ]'";
         string memory path = getPath(contractName);
 
         return getSelectors(query, path); 
     }
 
-    function getFunctionsWithModifier(string memory contractName, string memory modifierName) public returns (bytes4[] memory) {
+    function getFunctionsWithModifier(string memory contractName, string memory modifierName) internal returns (bytes4[] memory) {
         string memory query = string(bytes.concat("'[.ast.nodes[-1].nodes[] | if .nodeType == \"FunctionDefinition\" and .kind == \"function\" and ([.modifiers[] | .modifierName.name == \"", bytes(modifierName), "\" ] | any ) then .functionSelector else empty end ]'"));
         string memory path = getPath(contractName);
 


### PR DESCRIPTION
This change makes it so Quabi does not need to be deployed separately and linked to a contract using it (it can be compiled directly into the contracts bytecode).
 
 I ran into an issue while using Quabi and Echidna. Foundry handles this stuff under the hood i believe. But this change fixes it.